### PR TITLE
use 'target=test' query in IsOnline

### DIFF
--- a/pkg/metrics/providers/graphite.go
+++ b/pkg/metrics/providers/graphite.go
@@ -64,9 +64,10 @@ func NewGraphiteProvider(provider flaggerv1.MetricTemplateProvider) (*GraphitePr
 }
 
 // RunQuery executes the Graphite query and returns the the response.
+// TODO: this will need to conform to the provider interface and return a (float, error).
 func (g *GraphiteProvider) RunQuery(query string) (graphiteResponse, error) {
-	query = url.QueryEscape(g.trimQuery(query))
-	u, err := url.Parse(fmt.Sprintf("./render?format=json&%s", query))
+	query = g.trimQuery(query + "&format=json")
+	u, err := url.Parse(fmt.Sprintf("./render?%s", query))
 	if err != nil {
 		return nil, fmt.Errorf("url.Parase failed: %w", err)
 	}
@@ -109,7 +110,7 @@ func (g *GraphiteProvider) RunQuery(query string) (graphiteResponse, error) {
 // IsOnline runs a simple Graphite query and returns an error if the
 // API is unreachable.
 func (g *GraphiteProvider) IsOnline() (bool, error) {
-	_, err := g.RunQuery("")
+	_, err := g.RunQuery("target=test")
 	if err != nil {
 		return false, fmt.Errorf("running query failed: %w", err)
 	}

--- a/pkg/metrics/providers/graphite_test.go
+++ b/pkg/metrics/providers/graphite_test.go
@@ -79,7 +79,8 @@ func TestGraphiteProvider_IsOnline(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				if r.URL.Path != "/render" || "format=json" != r.URL.Query().Encode() {
+				fmt.Println(r.URL.Query().Encode())
+				if r.URL.Path != "/render" || r.URL.Query().Encode() != "format=json&target=test" {
 					w.WriteHeader(http.StatusNotFound)
 					return
 				}

--- a/pkg/metrics/providers/graphite_test.go
+++ b/pkg/metrics/providers/graphite_test.go
@@ -69,6 +69,12 @@ func TestGraphiteProvider_IsOnline(t *testing.T) {
 		200,
 		"[",
 	}, {
+		"Graphite responds 400",
+		false,
+		true,
+		400,
+		"error",
+	}, {
 		"Graphite responds 500",
 		false,
 		true,


### PR DESCRIPTION
'target=test' arguably serves as a more Graphite-idiomatic
"health check" query.