### PR TITLE
Initial RunQuery implementation.

### DIFF
--- a/pkg/metrics/providers/factory.go
+++ b/pkg/metrics/providers/factory.go
@@ -36,6 +36,8 @@ func (factory Factory) Provider(
 		return NewCloudWatchProvider(metricInterval, provider)
 	case "newrelic":
 		return NewNewRelicProvider(metricInterval, provider, credentials)
+	case "graphite":
+		return NewGraphiteProvider(provider, credentials)
 	default:
 		return NewPrometheusProvider(provider, credentials)
 	}

--- a/pkg/metrics/providers/graphite.go
+++ b/pkg/metrics/providers/graphite.go
@@ -87,7 +87,7 @@ type GraphiteProvider struct {
 // NewGraphiteProvider takes a provider spec and credentials map,
 // validates the address, extracts the  credentials map's username
 // and password values if provided, and returns a Graphite client
-// ready to execute queries against the API.
+// ready to execute queries against the Graphie render URL API.
 func NewGraphiteProvider(provider flaggerv1.MetricTemplateProvider, credentials map[string][]byte) (*GraphiteProvider, error) {
 	graphiteURL, err := url.Parse(provider.Address)
 	if provider.Address == "" || err != nil {
@@ -186,7 +186,7 @@ func (g *GraphiteProvider) RunQuery(query string) (float64, error) {
 // an error if the API is unreachable.
 func (g *GraphiteProvider) IsOnline() (bool, error) {
 	_, err := g.RunQuery("target=test")
-	if err != ErrNoValuesFound {
+	if err != nil && err != ErrNoValuesFound {
 		return false, fmt.Errorf("running query failed: %w", err)
 	}
 

--- a/pkg/metrics/providers/graphite.go
+++ b/pkg/metrics/providers/graphite.go
@@ -44,6 +44,10 @@ func (gdp *graphiteDataPoint) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	if len(v) != 2 {
+		return fmt.Errorf("error unmarshaling data point: %v", v)
+	}
+
 	switch v[0].(type) {
 	case nil:
 		// no value

--- a/pkg/metrics/providers/graphite.go
+++ b/pkg/metrics/providers/graphite.go
@@ -105,7 +105,7 @@ type GraphiteProvider struct {
 // NewGraphiteProvider takes a provider spec and credentials map,
 // validates the address, extracts the  credentials map's username
 // and password values if provided, and returns a Graphite client
-// ready to execute queries against the Graphie render URL API.
+// ready to execute queries against the Graphite render URL API.
 func NewGraphiteProvider(provider flaggerv1.MetricTemplateProvider, credentials map[string][]byte) (*GraphiteProvider, error) {
 	graphiteURL, err := url.Parse(provider.Address)
 	if provider.Address == "" || err != nil {


### PR DESCRIPTION
This PR adds a `RunQuery` implementation that conforms to the [metric provider](https://github.com/HBOCodeLabs/flagger/blob/main/pkg/metrics/providers/provider.go) interface.