### PR TITLE
Update MetricTemplate CRD

### DIFF
--- a/artifacts/flagger/crd.yaml
+++ b/artifacts/flagger/crd.yaml
@@ -1106,6 +1106,7 @@ spec:
                         - datadog
                         - cloudwatch
                         - newrelic
+                        - graphite
                     address:
                       description: API address of this provider
                       type: string

--- a/charts/flagger/crds/crd.yaml
+++ b/charts/flagger/crds/crd.yaml
@@ -1106,6 +1106,7 @@ spec:
                         - datadog
                         - cloudwatch
                         - newrelic
+                        - graphite
                     address:
                       description: API address of this provider
                       type: string

--- a/kustomize/base/flagger/crd.yaml
+++ b/kustomize/base/flagger/crd.yaml
@@ -1106,6 +1106,7 @@ spec:
                         - datadog
                         - cloudwatch
                         - newrelic
+                        - graphite
                     address:
                       description: API address of this provider
                       type: string


### PR DESCRIPTION
Add graphite to the list of valid provider types for the MetricTemplate CRD.